### PR TITLE
Fix no resistance effect when your average nutrition is in [95; 97)

### DIFF
--- a/config/nutrition/effects/resistance2.json
+++ b/config/nutrition/effects/resistance2.json
@@ -2,7 +2,7 @@
 	"name": "resistance2",
 	"potion": "minecraft:resistance",
 	"amplifier": 1,
-	"minimum": 97,
+	"minimum": 95,
 	"maximum": 100,
 	"detect": "average",
 	"enabled": true


### PR DESCRIPTION
It's quite strange that you don't get a resistance effect when your average nutrition is higher than 95 and less than 97. You should either have a resistance I or resistance II effect at this point.
Consider:
https://github.com/NillerMedDild/Enigmatica2ExpertSkyblock/blob/c50e1cf965c71af463712519319481f87314bce0/config/nutrition/effects/resistance.json#L1-L9